### PR TITLE
Add geocoder gem dependency with Google API key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
+gem 'geocoder'
+
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.6.0)
+    geocoder (1.3.4)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -176,6 +177,7 @@ DEPENDENCIES
   byebug
   capybara (= 2.7.0)
   coffee-rails (~> 4.1.0)
+  geocoder
   jbuilder (~> 2.0)
   jquery-rails
   rails (= 4.2.6)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,4 @@
+Geocoder.configure(
+  lookup: :google,
+  api_key: Rails.application.secrets.google_geo_api_key
+)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,11 +12,14 @@
 
 development:
   secret_key_base: d0bf0d3976b04523c29bced91023a44c926522b4c749582e92e029e19e7b5381cc4d91ef24f58ce0b78790d87430cf1db1d6d04ac12e3e2dcb12da2d2ea6c074
+  google_geo_api_key: AIzaSyDr7ODFV76uuLDY8OPt1_jSpBLBRYRUb8w
 
 test:
   secret_key_base: 1cca23fd07c8b446ddf36c755fd508cfd6ed50927d0875edae3582257f7dcf9ddf1ba692373d77c1003131c887bdbbbc5fde8712e58e6c3eb66a345a96761833
+  google_geo_api_key: AIzaSyDr7ODFV76uuLDY8OPt1_jSpBLBRYRUb8w
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  google_geo_api_key: <%= ENV["GOOGLE_GEO_API_KEY"] %>


### PR DESCRIPTION
The key is just for a test app on my account with no billing configured.

Fixes #8.
